### PR TITLE
ra-RoleEmailTable, utility file, tests and stories

### DIFF
--- a/frontend/src/fixtures/roleEmailFixtures.js
+++ b/frontend/src/fixtures/roleEmailFixtures.js
@@ -1,0 +1,18 @@
+const roleEmailFixtures = {
+  oneItem: {
+    email: "instructor1@example.com",
+  },
+  threeItems: [
+    {
+      email: "instructor1@example.com",
+    },
+    {
+      email: "admin1@example.com",
+    },
+    {
+      email: "instructor2@example.com",
+    },
+  ],
+};
+
+export { roleEmailFixtures };

--- a/frontend/src/main/components/Users/RoleEmailTable.js
+++ b/frontend/src/main/components/Users/RoleEmailTable.js
@@ -1,0 +1,47 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/RoleEmailUtils";
+import { hasRole } from "main/utils/currentUser";
+
+export default function RoleEmailTable({
+  items,
+  currentUser,
+  role,
+  testIdPrefix = "RoleEmailTable",
+}) {
+  //const role = hasRole(currentUser, "ROLE_ADMIN") ? "admin" : "instructor";
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    ({ cell }) => cellToAxiosParamsDelete(cell, role),
+    { onSuccess: onDeleteSuccess },
+    [`/api/${role.toLowerCase()}/all`],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate({ cell });
+  };
+
+  const columns = [
+    {
+      Header: "Email",
+      accessor: "email", // accessor is the "key" in the data
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={items} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/components/Users/RoleEmailTable.js
+++ b/frontend/src/main/components/Users/RoleEmailTable.js
@@ -13,22 +13,23 @@ export default function RoleEmailTable({
   currentUser,
   role,
   testIdPrefix = "RoleEmailTable",
+  deleteCallback: customDeleteCallback, // optional deleteCallback, used in AdminsIndexPage
 }) {
-  //const role = hasRole(currentUser, "ROLE_ADMIN") ? "admin" : "instructor";
-
   // Stryker disable all : hard to test for query caching
 
-  const deleteMutation = useBackendMutation(
-    ({ cell }) => cellToAxiosParamsDelete(cell, role),
+  const defaultDeleteMutation = useBackendMutation(
+    (cell) => cellToAxiosParamsDelete(cell, role),
     { onSuccess: onDeleteSuccess },
-    [`/api/${role.toLowerCase()}/all`],
+    [`/api/admin/${role.toLowerCase()}/all`],
   );
   // Stryker restore all
 
   // Stryker disable next-line all
-  const deleteCallback = async (cell) => {
-    deleteMutation.mutate({ cell });
+  const defaultDeleteCallback = async (cell) => {
+    defaultDeleteMutation.mutate(cell);
   };
+
+  const deleteCallback = customDeleteCallback || defaultDeleteCallback;
 
   const columns = [
     {
@@ -43,5 +44,11 @@ export default function RoleEmailTable({
     );
   }
 
-  return <OurTable data={items} columns={columns} testid={testIdPrefix} />;
+  return (
+    <OurTable
+      data={Array.isArray(items) ? items : []}
+      columns={columns}
+      testid={testIdPrefix}
+    />
+  );
 }

--- a/frontend/src/main/utils/RoleEmailUtils.js
+++ b/frontend/src/main/utils/RoleEmailUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell, role) {
+  return {
+    url: `/api/${role.toLowerCase()}`,
+    method: "DELETE",
+    params: {
+      email: cell.row.values.email,
+    },
+  };
+}

--- a/frontend/src/main/utils/RoleEmailUtils.js
+++ b/frontend/src/main/utils/RoleEmailUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell, role) {
   return {
-    url: `/api/${role.toLowerCase()}`,
+    url: `/api/admin/${role.toLowerCase()}`,
     method: "DELETE",
     params: {
       email: cell.row.values.email,

--- a/frontend/src/stories/components/Users/RoleEmailTable.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailTable.stories.js
@@ -21,14 +21,6 @@ Empty.args = {
   role: "admin",
 };
 
-export const ThreeItemsOrdinaryUser = Template.bind({});
-
-ThreeItemsOrdinaryUser.args = {
-  items: roleEmailFixtures.threeItems,
-  currentUser: currentUserFixtures.userOnly,
-  role: "instructor",
-};
-
 export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.args = {
   items: roleEmailFixtures.threeItems,
@@ -38,7 +30,7 @@ ThreeItemsAdminUser.args = {
 
 ThreeItemsAdminUser.parameters = {
   msw: [
-    http.delete(new RegExp("/api/(admin|instructor)"), () => {
+    http.delete(new RegExp("/api/admins/(admin|instructor)"), () => {
       return HttpResponse.json(
         { message: "Item deleted successfully" },
         { status: 200 },

--- a/frontend/src/stories/components/Users/RoleEmailTable.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailTable.stories.js
@@ -1,0 +1,48 @@
+import React from "react";
+import RoleEmailTable from "main/components/Users/RoleEmailTable";
+import { roleEmailFixtures } from "fixtures/roleEmailFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/Users/RoleEmailTable",
+  component: RoleEmailTable,
+};
+
+const Template = (args) => {
+  return <RoleEmailTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  items: [],
+  currentUser: currentUserFixtures.userOnly,
+  role: "admin",
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  items: roleEmailFixtures.threeItems,
+  currentUser: currentUserFixtures.userOnly,
+  role: "instructor",
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  items: roleEmailFixtures.threeItems,
+  currentUser: currentUserFixtures.adminUser,
+  role: "admin",
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete(new RegExp("/api/(admin|instructor)"), () => {
+      return HttpResponse.json(
+        { message: "Item deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -29,7 +29,7 @@ describe("RoleEmailTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <RoleEmailTable items={[]} currentUser={currentUser} role="admin" />
+          <RoleEmailTable items={[]} currentUser={currentUser} role="admins" />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -170,6 +170,37 @@ describe("RoleEmailTable tests", () => {
     await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
     expect(axiosMock.history.delete[0].params).toEqual({
       email: "instructor1@example.com",
+    });
+  });
+
+  test("handles rendering table gracefully when non-array object is passed", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RoleEmailTable
+            items={null}
+            currentUser={currentUser}
+            role="admins"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/components/Users/RoleEmailTable.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailTable.test.js
@@ -1,0 +1,175 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { roleEmailFixtures } from "fixtures/roleEmailFixtures";
+import RoleEmailTable from "main/components/Users/RoleEmailTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RoleEmailTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Email"];
+  const expectedFields = ["email"];
+  const testId = "RoleEmailTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RoleEmailTable items={[]} currentUser={currentUser} role="admin" />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RoleEmailTable
+            items={roleEmailFixtures.threeItems}
+            currentUser={currentUser}
+            role="admin"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-email`),
+    ).toHaveTextContent("instructor1@example.com");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-email`),
+    ).toHaveTextContent("admin1@example.com");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RoleEmailTable
+            items={roleEmailFixtures.threeItems}
+            currentUser={currentUser}
+            role="instructor"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-email`),
+    ).toHaveTextContent("instructor1@example.com");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-email`),
+    ).toHaveTextContent("admin1@example.com");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/instructor") // test would be the same for admin
+      .reply(200, { message: "Item deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RoleEmailTable
+            items={roleEmailFixtures.threeItems}
+            currentUser={currentUser}
+            role="instructor"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-email`),
+    ).toHaveTextContent("instructor1@example.com");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({
+      email: "instructor1@example.com",
+    });
+  });
+});

--- a/frontend/src/tests/utils/roleEmail.test.js
+++ b/frontend/src/tests/utils/roleEmail.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/RoleEmailUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("RoleEmailUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { email: "testemail@ucsb.edu" } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell, "admin");
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/admin",
+        method: "DELETE",
+        params: { email: "testemail@ucsb.edu" },
+      });
+    });
+  });
+});

--- a/frontend/src/tests/utils/roleEmail.test.js
+++ b/frontend/src/tests/utils/roleEmail.test.js
@@ -38,11 +38,11 @@ describe("RoleEmailUtils", () => {
       const cell = { row: { values: { email: "testemail@ucsb.edu" } } };
 
       // act
-      const result = cellToAxiosParamsDelete(cell, "admin");
+      const result = cellToAxiosParamsDelete(cell, "admins");
 
       // assert
       expect(result).toEqual({
-        url: "/api/admin",
+        url: "/api/admin/admins",
         method: "DELETE",
         params: { email: "testemail@ucsb.edu" },
       });


### PR DESCRIPTION
Closes #26 

In this PR, we create the RoleEmailTable, which lists the emails of instructors or admins. This table can be used for Instructor index page or the Admin index page and other corresponding components. 

You can view the storybook here : https://6823eb897f17ca4b3da8b15d-dstragzndd.chromatic.com/?path=/story/components-users-roleemailtable--empty

# Screenshots
![Screenshot 2025-05-19 130103](https://github.com/user-attachments/assets/d05379fd-cf5d-41f0-a232-7641496837a8)

![Screenshot 2025-05-19 130049](https://github.com/user-attachments/assets/4ec3bf7b-3c51-464b-961c-a0a0a2aa236a)

![Screenshot 2025-05-19 130028](https://github.com/user-attachments/assets/cc08a222-25c0-4905-9176-f36be80a65db)
