### PR TITLE
ra-RoleEmailForm, tests and stories

### DIFF
--- a/frontend/src/main/components/Users/RoleEmailForm.js
+++ b/frontend/src/main/components/Users/RoleEmailForm.js
@@ -1,0 +1,56 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function RoleEmailForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Add Email",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "RoleEmailForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          id="email"
+          data-testid={testIdPrefix + "-email"}
+          type="email"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, // email regex for simple fomatting validation
+              message: "Please enter a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit">{buttonLabel}</Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default RoleEmailForm;

--- a/frontend/src/stories/components/Users/RoleEmailForm.stories.js
+++ b/frontend/src/stories/components/Users/RoleEmailForm.stories.js
@@ -1,0 +1,22 @@
+import React from "react";
+import RoleEmailForm from "main/components/Users/RoleEmailForm";
+
+export default {
+  title: "components/Users/RoleEmailForm",
+  component: RoleEmailForm,
+};
+
+const Template = (args) => {
+  return <RoleEmailForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  initialContents: {},
+  buttonLabel: "Add Email",
+  submitAction: (data) => {
+    console.log("Submitted with: ", data);
+    window.alert("Submitted with: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -78,4 +78,75 @@ describe("RoleEmailForm tests", () => {
       ).toBeInTheDocument();
     });
   });
+
+  test("shows error on invalid email with partial valid email", async () => {
+    const mockSubmit = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm submitAction={mockSubmit} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    const testInput = screen.getByTestId(`${testId}-email`);
+    const submitButton = screen.getByRole("button", { name: /Add Email/i });
+
+    fireEvent.change(testInput, { target: { value: "valid@email.com invalid" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Please enter a valid email address./i)).toBeInTheDocument();
+    });
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  test("shows error on invalid email", async () => {
+    const mockSubmit = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm submitAction={mockSubmit} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    const testInput = screen.getByTestId(`${testId}-email`);
+    const submitButton = screen.getByRole("button", { name: /Add Email/i });
+
+    fireEvent.change(testInput, { target: { value: "invalid email@ucsb.edu" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Please enter a valid email address./i)).toBeInTheDocument();
+    });
+
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+  
+  test("does not show error on valid email and submits", async () => {
+    const mockSubmit = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm submitAction={mockSubmit} />
+        </Router>
+      </QueryClientProvider>
+    );
+
+    const input = screen.getByLabelText(/email/i);
+    const submitButton = screen.getByRole("button", { name: /add email/i });
+
+    fireEvent.change(input, { target: { value: "user@ucsb.com" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalled();
+    });
+  });
+
 });

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -87,17 +87,21 @@ describe("RoleEmailForm tests", () => {
         <Router>
           <RoleEmailForm submitAction={mockSubmit} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const testInput = screen.getByTestId(`${testId}-email`);
     const submitButton = screen.getByRole("button", { name: /Add Email/i });
 
-    fireEvent.change(testInput, { target: { value: "valid@email.com invalid" } });
+    fireEvent.change(testInput, {
+      target: { value: "valid@email.com invalid" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Please enter a valid email address./i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Please enter a valid email address./i),
+      ).toBeInTheDocument();
     });
 
     expect(mockSubmit).not.toHaveBeenCalled();
@@ -111,22 +115,26 @@ describe("RoleEmailForm tests", () => {
         <Router>
           <RoleEmailForm submitAction={mockSubmit} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const testInput = screen.getByTestId(`${testId}-email`);
     const submitButton = screen.getByRole("button", { name: /Add Email/i });
 
-    fireEvent.change(testInput, { target: { value: "invalid email@ucsb.edu" } });
+    fireEvent.change(testInput, {
+      target: { value: "invalid email@ucsb.edu" },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Please enter a valid email address./i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Please enter a valid email address./i),
+      ).toBeInTheDocument();
     });
 
     expect(mockSubmit).not.toHaveBeenCalled();
   });
-  
+
   test("does not show error on valid email and submits", async () => {
     const mockSubmit = jest.fn();
 
@@ -135,7 +143,7 @@ describe("RoleEmailForm tests", () => {
         <Router>
           <RoleEmailForm submitAction={mockSubmit} />
         </Router>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const input = screen.getByLabelText(/email/i);
@@ -148,5 +156,4 @@ describe("RoleEmailForm tests", () => {
       expect(mockSubmit).toHaveBeenCalled();
     });
   });
-
 });

--- a/frontend/src/tests/components/Users/RoleEmailForm.test.js
+++ b/frontend/src/tests/components/Users/RoleEmailForm.test.js
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import RoleEmailForm from "main/components/Users/RoleEmailForm";
+import { _roleEmailFixtures } from "fixtures/roleEmailFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("RoleEmailForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Email"];
+  const testId = "RoleEmailForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Add Email/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <RoleEmailForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Add Email/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Add Email/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Email is required./);
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+
+    const testInput = screen.getByTestId(`${testId}-email`);
+    fireEvent.change(testInput, { target: { value: "notanemail" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Please enter a valid email address./),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #16 

In this PR, we add RoleEmailForm to add a new email. This form can be used for both the Instructors pages and Admin pages.

See the storybook at: https://6823eb897f17ca4b3da8b15d-pzsknrdgzx.chromatic.com/?path=/story/components-users-roleemailform--create

# Screenshots 
![Screenshot 2025-05-19 153546](https://github.com/user-attachments/assets/fafc7355-9fa9-4167-8e37-a4db95588e45)

![image](https://github.com/user-attachments/assets/c3dbc590-c3f9-4880-a734-f64f0f23dae7)

![image](https://github.com/user-attachments/assets/e08f6ca9-71c7-4f71-8ce6-5b951f7d5369)