### PR TITLE
JS - added update crud operation for student roster and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
 import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+
+import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import lombok.extern.slf4j.Slf4j;
@@ -67,4 +69,19 @@ public abstract class ApiController {
             "message", e.getMessage()
     );
   }
+
+      /**
+     * This method handles BadRequestException.
+     * @param e the exception
+     * @return a map with the type and message of the exception
+     */
+    @ExceptionHandler({ BadRequestException.class })
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Object handleBadRequestException(Throwable e) {
+      return Map.of(
+        "type",    e.getClass().getSimpleName(),
+        "message", e.getMessage()
+      );
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -37,6 +37,7 @@ import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
 import com.opencsv.CSVReader;
@@ -233,4 +234,57 @@ public class RosterStudentsController extends ApiController {
         Iterable<RosterStudent> rosterStudents = rosterStudentRepository.findAllByUser((currentUser));
         return rosterStudents;
     }
+
+    /**
+     * Update first name, last name, and student number of an existing roster student.
+     * 
+     * @param id the RosterStudent record ID
+     * @param firstName new first name
+     * @param lastName new last name
+     * @param studentId new student number (must be unique within the same course)
+     * @return the updated RosterStudent
+     * @throws EntityNotFoundException if no RosterStudent exists with that ID
+     * @throws BadRequestException if the new student number duplicates another in the same course
+     */
+    @Operation(summary = "Update a roster student's name and student number")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/{id}")
+    public RosterStudent updateRosterStudent(
+            @Parameter(name = "id", description = "RosterStudent record ID") 
+            @PathVariable Long id,
+
+            @Parameter(name = "firstName", description = "New first name") 
+            @RequestParam String firstName,
+
+            @Parameter(name = "lastName", description = "New last name") 
+            @RequestParam String lastName,
+
+            @Parameter(name = "studentId", description = "New student number") 
+            @RequestParam String studentId
+    ) throws EntityNotFoundException, BadRequestException {
+
+        RosterStudent rs = rosterStudentRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+
+        if (!rs.getStudentId().equals(studentId)) {
+            Optional<RosterStudent> duplicate = 
+                rosterStudentRepository.findByCourseIdAndStudentId(
+                    rs.getCourse().getId(), studentId);
+
+            if (duplicate.isPresent()) {
+                throw new BadRequestException(
+                    String.format("Student number '%s' is already used in course %d",
+                                  studentId, rs.getCourse().getId()));
+            }
+            rs.setStudentId(studentId);
+        }
+
+        rs.setFirstName(firstName);
+        rs.setLastName(lastName);
+
+        return rosterStudentRepository.save(rs);
+    }
+
+
 }
+

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -284,7 +284,5 @@ public class RosterStudentsController extends ApiController {
 
         return rosterStudentRepository.save(rs);
     }
-
-
 }
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
@@ -2,13 +2,18 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import edu.ucsb.cs156.frontiers.ControllerTestCase;
 import edu.ucsb.cs156.frontiers.controllers.ApiController;
+import edu.ucsb.cs156.frontiers.models.CurrentUser;
 import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
 
+import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -17,6 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = DummyController.class)
 @Import(TestConfig.class)
@@ -71,6 +78,31 @@ public class ApiControllerTests extends ControllerTestCase {
                 assertEquals("NoLinkedOrganizationException", json.get("type"));
                 assertEquals("No linked GitHub Organization to course. Please link a GitHub Organization first.", json.get("message"));
         }
+
+        @Test
+        public void handleBadRequestException_returnsTypeAndMessage() {
+                // Arrange: make an instance of your controller (DummyController extends ApiController)
+                ApiController controller = new DummyController();
+
+                // Create the same exception you throw in your endpoint
+                BadRequestException ex = new BadRequestException(
+                "Student number 'X' is already used in course 1"
+                );
+
+                // Act: call the exception handler directly
+                Object raw = controller.handleBadRequestException(ex);
+
+                // Assert: it returns a Map with the correct entries
+                @SuppressWarnings("unchecked")
+                Map<String, Object> result = (Map<String, Object>) raw;
+
+                assertEquals("BadRequestException", result.get("type"));
+                assertEquals(
+                "Student number 'X' is already used in course 1",
+                result.get("message")
+                );
+        }
+    
 
 }
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/ApiControllerTests.java
@@ -81,18 +81,16 @@ public class ApiControllerTests extends ControllerTestCase {
 
         @Test
         public void handleBadRequestException_returnsTypeAndMessage() {
-                // Arrange: make an instance of your controller (DummyController extends ApiController)
                 ApiController controller = new DummyController();
 
-                // Create the same exception you throw in your endpoint
                 BadRequestException ex = new BadRequestException(
                 "Student number 'X' is already used in course 1"
                 );
 
-                // Act: call the exception handler directly
+                // act
                 Object raw = controller.handleBadRequestException(ex);
 
-                // Assert: it returns a Map with the correct entries
+                // assert
                 @SuppressWarnings("unchecked")
                 Map<String, Object> result = (Map<String, Object>) raw;
 

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -740,46 +740,52 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 String expectedJson = mapper.writeValueAsString(List.of());
                 assertEquals(expectedJson, responseString);
         }
-        
+
         @Test
         @WithMockUser(roles = "ADMIN")
         public void updateRosterStudent_success_noIdChange() throws Exception {
-                doReturn(Optional.of(rs2))
-                .when(rosterStudentRepository).findById(2L);
-                doReturn(rs2)
-                .when(rosterStudentRepository).save(any(RosterStudent.class));
+        doReturn(Optional.of(rs2))
+        .when(rosterStudentRepository).findById(2L);
+        doReturn(rs2)
+        .when(rosterStudentRepository).save(any(RosterStudent.class));
 
-                mockMvc.perform(put("/api/rosterstudents/2")
-                        .with(csrf())
-                        .param("firstName", rs2.getFirstName())
-                        .param("lastName",  rs2.getLastName())
-                        .param("studentId", rs2.getStudentId()))
+        mockMvc.perform(put("/api/rosterstudents/2")
+                .with(csrf())
+                .param("firstName", "AliceNew")
+                .param("lastName",  "BobNew")
+                .param("studentId", rs2.getStudentId()))
                 .andExpect(status().isOk())
+
+                .andExpect(jsonPath("$.firstName").value("AliceNew"))
+                .andExpect(jsonPath("$.lastName").value("BobNew"))
                 .andExpect(jsonPath("$.studentId").value(rs2.getStudentId()));
 
-                verify(rosterStudentRepository, never())
+        verify(rosterStudentRepository, never())
                 .findByCourseIdAndStudentId(anyLong(), anyString());
         }
 
         @Test
         @WithMockUser(roles = "ADMIN")
         public void updateRosterStudent_success_withIdChange() throws Exception {
-                doReturn(Optional.of(rs2))
-                .when(rosterStudentRepository).findById(2L);
-                doReturn(Optional.empty())
-                .when(rosterStudentRepository)
-                .findByCourseIdAndStudentId(eq(course1.getId()), eq("NEWID"));
-                doReturn(rs2)
-                .when(rosterStudentRepository).save(any(RosterStudent.class));
+        doReturn(Optional.of(rs2))
+        .when(rosterStudentRepository).findById(2L);
+        doReturn(Optional.empty())
+        .when(rosterStudentRepository)
+        .findByCourseIdAndStudentId(eq(course1.getId()), eq("NEWID"));
+        doReturn(rs2)
+        .when(rosterStudentRepository).save(any(RosterStudent.class));
 
-                mockMvc.perform(put("/api/rosterstudents/2")
-                        .with(csrf())
-                        .param("firstName", rs2.getFirstName())
-                        .param("lastName",  rs2.getLastName())
-                        .param("studentId", "NEWID"))
+        mockMvc.perform(put("/api/rosterstudents/2")
+                .with(csrf())
+                .param("firstName", "CharlieX")
+                .param("lastName",  "DeltaY")
+                .param("studentId", "NEWID"))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("CharlieX"))
+                .andExpect(jsonPath("$.lastName").value("DeltaY"))
                 .andExpect(jsonPath("$.studentId").value("NEWID"));
         }
+
 
         @Test
         @WithMockUser(roles = "ADMIN")
@@ -826,6 +832,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         .param("studentId", "X123"))
                 .andExpect(status().isForbidden());
         }
+
         @Test
         public void noArgsConstructor_and_setters_getters_work() {
         RosterStudentDTO dto = new RosterStudentDTO();


### PR DESCRIPTION
Closes #25 

Does not rely on other PRs to merge.

In this PR we add the update operation for Roster Students to be able to edit first name, last name, and student number for existing Roster Students.

![image](https://github.com/user-attachments/assets/eb67d03d-61aa-4902-8b5d-179734cfc6dc)

To test: 
1. visit the dokku deployment : https://proj-frontiers-dev-jsanchez021.dokku-09.cs.ucsb.edu/
2. log in with google oauth
3. navigate to swagger
4. create a course if none exists
5. create a roster student if none exists
6. edit that roster student