### PR TITLE
jz-created entity, repository, and db migration files for Admins Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Admin.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Admin.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.frontiers.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "ADMINS")
+public class Admin {
+
+    @Id
+    private String email;
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.frontiers.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import edu.ucsb.cs156.frontiers.entities.Admin;
+
+@Repository
+public interface AdminRepository extends CrudRepository<Admin, String> {}

--- a/src/main/resources/db/migration/changes/007-create-Admins.json
+++ b/src/main/resources/db/migration/changes/007-create-Admins.json
@@ -1,0 +1,41 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Admins-1",
+        "author": "JasonZ",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": {
+              "tableExists": {
+                "tableName": "ADMINS"
+              }
+            }
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "ADMINS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)",
+                    "constraints": {
+                      "primaryKey": true,
+                      "nullable": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/db/migration/changes/007-create-Admins.json
+++ b/src/main/resources/db/migration/changes/007-create-Admins.json
@@ -2,8 +2,8 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "Admins-1",
-        "author": "JasonZ",
+        "id": "007-create-Admins",
+        "author": "jasosh5",
         "preConditions": [
           {
             "onFail": "MARK_RAN"


### PR DESCRIPTION
Closes #13 

In this PR, I added the entity, repository, and the database migration files for the Admins table. The admin class only has one field which is the email field and it acts as the ID. 

# To test the new files:

1.) Go onto the dokku console and open up the postgres command line by running the command: dokku postgres:connect proj-dev-jasozh5

2.) Run \dt in the postgres command line and you can see that the admins table exists. 

Dokku Deployment:  https://proj-dev-jasozh5.dokku-09.cs.ucsb.edu 

Screenshot of \dt in the postgres command line: 
![image](https://github.com/user-attachments/assets/648ab808-62e4-429e-88be-d9d70560ad12)

