### PR TITLE
ra-AdminsIndexPage, tests and stories

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,8 @@ import "bootstrap/dist/css/bootstrap.css";
 import "react-toastify/dist/ReactToastify.css";
 import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
 
+import AdminsIndexPage from "main/pages/Admins/AdminsIndexPage";
+
 function App() {
   const { data: currentUser } = useCurrentUser();
 
@@ -22,6 +24,9 @@ function App() {
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/courses" element={<CoursesIndexPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <Route exact path="/admin/admins" element={<AdminsIndexPage />} />
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -60,6 +60,9 @@ export default function AppNavbar({
                   <NavDropdown.Item href="/admin/courses">
                     Courses
                   </NavDropdown.Item>
+                  <NavDropdown.Item href="/admin/admins">
+                    Admins
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/main/pages/Admins/AdminsIndexPage.js
+++ b/frontend/src/main/pages/Admins/AdminsIndexPage.js
@@ -35,9 +35,9 @@ export default function AdminsIndexPage() {
   };
 
   const onError = (error) => {
-    const message = error.response?.data;
+    const message = error.response.data;
 
-    if (error.response?.status === 403 && typeof message === "string") {
+    if (error.response.status === 403 && typeof message === "string") {
       toast.error(message);
     } else {
       toast.error("Error deleting admin.");

--- a/frontend/src/main/pages/Admins/AdminsIndexPage.js
+++ b/frontend/src/main/pages/Admins/AdminsIndexPage.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RoleEmailTable from "main/components/Users/RoleEmailTable";
+import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
+import { toast } from "react-toastify";
+
+export default function AdminsIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: admins,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/admin/admins"],
+    { method: "GET", url: "/api/admin/admins" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const objectToAxiosParams = (cell) => ({
+    url: "/api/admin/admins",
+    method: "DELETE",
+    params: {
+      email: cell.row.values.email,
+    },
+  });
+
+  const onSuccess = (response) => {
+    toast(`Admin with email ${response.email} deleted`);
+  };
+
+  const onError = (error) => {
+    const message = error.response?.data;
+
+    if (error.response?.status === 403 && typeof message === "string") {
+      toast.error(message);
+    } else {
+      toast.error("Error deleting admin.");
+    }
+  };
+
+  const deleteMutation = useBackendMutation(objectToAxiosParams, {
+    onSuccess,
+    onError,
+  });
+
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const createButton = () => {
+    return (
+      <Button
+        variant="primary"
+        href="/admin/admins/create"
+        style={{ float: "right" }}
+      >
+        New Admin
+      </Button>
+    );
+  };
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        {createButton()}
+        <h1>Admins</h1>
+        <RoleEmailTable
+          items={admins}
+          currentUser={currentUser}
+          role="admins"
+          deleteCallback={deleteCallback}
+        />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Admins/AdminsIndexPage.js
+++ b/frontend/src/main/pages/Admins/AdminsIndexPage.js
@@ -33,8 +33,8 @@ export default function AdminsIndexPage() {
     },
   });
 
-  const onSuccess = (response) => {
-    toast(`Admin with email ${response.email} deleted`);
+  const onSuccess = (email) => {
+    toast(`Admin with email ${email} deleted`);
     queryClient.invalidateQueries({ queryKey: ["/api/admin/admins/all"] });
   };
 
@@ -49,12 +49,13 @@ export default function AdminsIndexPage() {
   };
 
   const deleteMutation = useBackendMutation(objectToAxiosParams, {
-    onSuccess,
     onError,
   });
 
   const deleteCallback = async (cell) => {
-    deleteMutation.mutate(cell);
+    deleteMutation.mutate(cell, {
+      onSuccess: () => onSuccess(cell.row.values.email),
+    });
   };
 
   const createButton = () => {

--- a/frontend/src/main/pages/Admins/AdminsIndexPage.js
+++ b/frontend/src/main/pages/Admins/AdminsIndexPage.js
@@ -7,7 +7,10 @@ import { useCurrentUser } from "main/utils/currentUser";
 import { Button } from "react-bootstrap";
 import { toast } from "react-toastify";
 
+import { useQueryClient } from "react-query";
+
 export default function AdminsIndexPage() {
+  const queryClient = useQueryClient();
   const currentUser = useCurrentUser();
 
   const {
@@ -16,8 +19,8 @@ export default function AdminsIndexPage() {
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/admin/admins"],
-    { method: "GET", url: "/api/admin/admins" },
+    ["/api/admin/admins/all"],
+    { method: "GET", url: "/api/admin/admins/all" },
     // Stryker disable next-line all : don't test default value of empty list
     [],
   );
@@ -32,6 +35,7 @@ export default function AdminsIndexPage() {
 
   const onSuccess = (response) => {
     toast(`Admin with email ${response.email} deleted`);
+    queryClient.invalidateQueries({ queryKey: ["/api/admin/admins/all"] });
   };
 
   const onError = (error) => {

--- a/frontend/src/stories/pages/Admins/AdminsIndexPage.stories.js
+++ b/frontend/src/stories/pages/Admins/AdminsIndexPage.stories.js
@@ -27,7 +27,7 @@ Empty.parameters = {
         status: 200,
       });
     }),
-    http.get("/api/admin/admins", () => {
+    http.get("/api/admin/admins/all", () => {
       return HttpResponse.json([], { status: 200 });
     }),
   ],
@@ -43,7 +43,7 @@ ThreeItemsAdminUser.parameters = {
     http.get("/api/systemInfo", () => {
       return HttpResponse.json(systemInfoFixtures.showingNeither);
     }),
-    http.get("/api/admin/admins", () => {
+    http.get("/api/admin/admins/all", () => {
       return HttpResponse.json(roleEmailFixtures.threeItems);
     }),
     http.delete("/api/admin/admins", () => {

--- a/frontend/src/stories/pages/Admins/AdminsIndexPage.stories.js
+++ b/frontend/src/stories/pages/Admins/AdminsIndexPage.stories.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { roleEmailFixtures } from "fixtures/roleEmailFixtures";
+import { http, HttpResponse } from "msw";
+
+import AdminsIndexPage from "main/pages/Admins/AdminsIndexPage";
+
+export default {
+  title: "pages/Admins/AdminsIndexPage",
+  component: AdminsIndexPage,
+};
+
+const Template = () => <AdminsIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/admin/admins", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/admin/admins", () => {
+      return HttpResponse.json(roleEmailFixtures.threeItems);
+    }),
+    http.delete("/api/admin/admins", () => {
+      return HttpResponse.json(
+        { message: "Item deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Admins/AdminsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admins/AdminsIndexPage.test.js
@@ -276,7 +276,7 @@ describe("AdminsIndexPage tests", () => {
     axiosMock
       .onDelete("/api/admin/admins", { params: { email: admin.email } })
       .reply(() => {
-        throw { message: "Network Error" }; // this error doesn't have a response property
+        throw new Error("Network Error"); // this error doesn't have a response property
       });
 
     const restoreConsole = mockConsole();
@@ -304,7 +304,7 @@ describe("AdminsIndexPage tests", () => {
 
     await waitFor(() => {
       expect(mockToast.mock.calls).toContainEqual([
-        "Axios Error: [object Object]",
+        "Axios Error: Error: Network Error",
       ]);
     });
 

--- a/frontend/src/tests/pages/Admins/AdminsIndexPage.test.js
+++ b/frontend/src/tests/pages/Admins/AdminsIndexPage.test.js
@@ -45,7 +45,7 @@ describe("AdminsIndexPage tests", () => {
 
   test("Renders with New Admin Button", async () => {
     setupAdminUser();
-    axiosMock.onGet("/api/admin/admins").reply(200, []);
+    axiosMock.onGet("/api/admin/admins/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Closes #41 (which is a sub-issue of issue 18)

NOTE: #53 needs to be merged first, then this branch will need to be rebased off main. The dokku deployment will need to be re-synced and rebuilt right after.

In this PR, we add the index page for the admins table. We modify App.js to add routing to the page, as well as AppNavbar.js to show Instructors on the toggle feature. Note that the backend endpoints have not been implemented yet. Similar to the instructors table, I decided for the sorting functionality to be implemented server side at the database layer (will live inside the controller for Instructors) because:
1.) Offloading sorting to the database ensures that the client receives already sorted data, reducing the complexity of React state or logic and guaranteeing consistent ordering across different views.
2.) Cleaner code, we can simply use Sort.by("email") keeping the controller logic concise.

RoleEmailTable.js and RoleEmailUtil.js were also modified to support the functionality of not allowing users to delete an admin who's email is in ADMINS_EMAIL. The backend should and will take care of this check and send a 403 error to the frontend, which is handled in the mentioned modified files.

See the storybook at: https://6823eb897f17ca4b3da8b15d-hrnwdnorxa.chromatic.com/?path=/story/pages-admins-adminsindexpage--empty
See the dokku deployment at: https://frontiers-rubenalvarezgj-dev2.dokku-09.cs.ucsb.edu/

# Screenshots
![image](https://github.com/user-attachments/assets/5319d304-9fe5-4bfa-b559-db20be8f4bd8)

![image](https://github.com/user-attachments/assets/ab3ce08b-8084-443d-9bdc-a8f940cfdfe8)
