### PR TITLE
ra-AdminCreatePage, tests and stories

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import "react-toastify/dist/ReactToastify.css";
 import CoursesIndexPage from "main/pages/Courses/CoursesIndexPage";
 
 import AdminsIndexPage from "main/pages/Admins/AdminsIndexPage";
+import AdminsCreatePage from "main/pages/Admins/AdminsCreatePage";
 
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -27,6 +28,13 @@ function App() {
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/admins" element={<AdminsIndexPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <Route
+            exact
+            path="/admin/admins/create"
+            element={<AdminsCreatePage />}
+          />
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/main/pages/Admins/AdminsCreatePage.js
+++ b/frontend/src/main/pages/Admins/AdminsCreatePage.js
@@ -21,7 +21,7 @@ export default function AdminsCreatePage({ storybook = false }) {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    ["/api/admin/admins"], // mutation makes this key stale so that pages relying on it reload
+    ["/api/admin/admins/all"], // mutation makes this key stale so that pages relying on it reload
   );
 
   const { isSuccess } = mutation;
@@ -31,7 +31,7 @@ export default function AdminsCreatePage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/admins" />;
+    return <Navigate to="/admin/admins" />;
   }
 
   return (

--- a/frontend/src/main/pages/Admins/AdminsCreatePage.js
+++ b/frontend/src/main/pages/Admins/AdminsCreatePage.js
@@ -1,0 +1,45 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RoleEmailForm from "main/components/Users/RoleEmailForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function AdminsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (admin) => ({
+    url: "/api/admin/admins/post",
+    method: "POST",
+    params: {
+      email: admin.email,
+    },
+  });
+
+  const onSuccess = (admin) => {
+    toast(`New admin added - email: ${admin.email}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/admin/admins"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/admins" />;
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Add New Admin</h1>
+        <RoleEmailForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/Admins/AdminsCreatePage.stories.js
+++ b/frontend/src/stories/pages/Admins/AdminsCreatePage.stories.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import AdminsCreatePage from "main/pages/Admins/AdminsCreatePage";
+
+import { roleEmailFixtures } from "fixtures/roleEmailFixtures";
+
+export default {
+  title: "pages/Admins/AdminsCreatePage",
+  component: AdminsCreatePage,
+};
+
+const Template = () => <AdminsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/admin/admins/post", () => {
+      return HttpResponse.json(roleEmailFixtures.oneItem, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Admins/AdminsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admins/AdminsCreatePage.test.js
@@ -62,7 +62,7 @@ describe("AdminsCreatePage tests", () => {
     });
   });
 
-  test("on submit, makes request to backend, and redirects to /admins", async () => {
+  test("on submit, makes request to backend, and redirects to /admin/admins", async () => {
     const queryClient = new QueryClient();
     const admin = {
       email: "testemailone@ucsb.edu",
@@ -105,7 +105,7 @@ describe("AdminsCreatePage tests", () => {
       "New admin added - email: testemailone@ucsb.edu",
     );
     expect(mockNavigate).toHaveBeenCalledWith({
-      to: "/admins",
+      to: "/admin/admins",
     });
   });
 });

--- a/frontend/src/tests/pages/Admins/AdminsCreatePage.test.js
+++ b/frontend/src/tests/pages/Admins/AdminsCreatePage.test.js
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdminsCreatePage from "main/pages/Admins/AdminsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
+
+describe("AdminsCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  const queryClient = new QueryClient();
+  test("renders without crashing", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /admins", async () => {
+    const queryClient = new QueryClient();
+    const admin = {
+      email: "testemailone@ucsb.edu",
+    };
+
+    axiosMock.onPost("/api/admin/admins/post").reply(202, admin);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByLabelText("Email");
+    expect(emailInput).toBeInTheDocument();
+
+    const AddButton = screen.getByText("Add Email");
+    expect(AddButton).toBeInTheDocument();
+
+    fireEvent.change(emailInput, {
+      target: { value: "testemailone@ucsb.edu" },
+    });
+
+    fireEvent.click(AddButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      email: "testemailone@ucsb.edu",
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New admin added - email: testemailone@ucsb.edu",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: "/admins",
+    });
+  });
+});


### PR DESCRIPTION
Closes #40 (which is the final sub-issue of issue 18 so this closes that issue too)

NOTE: #53 needs to be merged first, then this branch will need to be rebased off main. The dokku deployment will need to be re-synced and rebuilt right after.

In this PR, we create a create page for the admins table. We modify App.js to add routing to the page. Note that the backend endpoints have not been implemented yet.

See storybook here: https://6823eb897f17ca4b3da8b15d-eqazzxanyp.chromatic.com/?path=/story/pages-admins-adminscreatepage--default

See dokku deployment here: https://frontiers-rubenalvarezgj-dev2.dokku-09.cs.ucsb.edu/

# Screenshots
![image](https://github.com/user-attachments/assets/983f1c38-5075-43ca-b119-63a0ef410965)

![image](https://github.com/user-attachments/assets/6c4c51a5-723e-4600-b198-74fccacdc9b1)
