### PR TITLE
JS - added delete crud operation for student roster and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -284,5 +284,22 @@ public class RosterStudentsController extends ApiController {
 
         return rosterStudentRepository.save(rs);
     }
+
+    @Operation(summary = "Delete a roster student by record ID")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteRosterStudentById(
+        @Parameter(description = "RosterStudent record ID") @PathVariable Long id)
+        throws EntityNotFoundException {
+
+        RosterStudent rs = rosterStudentRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+
+        rosterStudentRepository.delete(rs);
+
+        return ResponseEntity.ok(
+            String.format("Deleted roster student %d", id));
+    }
+
 }
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
@@ -41,7 +41,7 @@ public class Course {
     @ToString.Exclude
     private List<CourseStaff> courseStaff;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "course")
+    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "course")
     @Fetch(FetchMode.JOIN)
     @JsonIgnore
     @ToString.Exclude


### PR DESCRIPTION
Closes #20 and #17 

Merge after #37 

In this PR we add a delete operation to delete a roster student entry by record id.

![image](https://github.com/user-attachments/assets/235a9459-43cb-4ae0-bf2f-a9451d04d7e1)

To test:
1. visit the dokku deployment https://proj-frontiers-dev-jsanchez021.dokku-09.cs.ucsb.edu/
2. log in
3. create a roster student
4. delete a roster student by record id
5. confirm that it has been deleted by listing all roster students for a course.