### PR TITLE
Jz - admin controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminController.java
@@ -1,0 +1,101 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import java.util.List;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "Admins")
+@RequestMapping("/api/admins")
+@RestController
+@Slf4j
+public class AdminController extends ApiController{
+    @Autowired
+    AdminRepository adminRepository;
+
+    // @Value("${ADMIN_EMAILS:}")
+    // private String adminEmailsRaw;
+
+    // private List<String> adminEmails;
+
+    // @PostConstruct
+    // public void init() {
+
+    //     log.info("Loaded ADMIN_EMAILS: '{}'", adminEmailsRaw);
+
+    //     if (adminEmailsRaw != null && !adminEmailsRaw.isBlank()) {
+    //         adminEmails = List.of(adminEmailsRaw.split("\\s*,\\s*"));
+    //     } else {
+    //         adminEmails = List.of(); // default to empty list
+    //     }
+
+    //     log.info("Parsed adminEmails list: {}", adminEmails);
+
+
+    // }
+    @Value("#{'${app.admin-emails}'.split(',')}")
+    private List<String> adminEmails;
+
+    @Operation(summary= "List all Admins")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Admin> allAdmin() {
+        Iterable<Admin> admin = adminRepository.findAll();
+        return admin;
+    }
+
+    @Operation(summary= "Create a new admin")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Admin postAdmin(
+    @Parameter(name="email") @RequestParam String email)
+    throws JsonProcessingException {
+
+
+
+    Admin admin = new Admin();
+    admin.setEmail(email);
+
+    Admin savedAdmin = adminRepository.save(admin);
+
+    return savedAdmin;
+    }
+
+    @Operation(summary= "Delete an Admin")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteAdmin(@Parameter(name="email") @RequestParam String email) {
+        
+        if (adminEmails.contains(email)) {
+            throw new UnsupportedOperationException("Cannot delete admin email: " + email);
+        }
+
+        Admin  admin = adminRepository.findById(email)
+                .orElseThrow(() -> new EntityNotFoundException(Admin.class, email));
+
+        adminRepository.delete(admin);
+        return genericMessage("Admin with email is deleted".formatted(email));
+    }
+
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
-import java.util.List;
-
+import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,39 +20,18 @@ import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 
 @Tag(name = "Admins")
-@RequestMapping("/api/admins")
+@RequestMapping("/api/admin/admins")
 @RestController
 @Slf4j
 public class AdminController extends ApiController{
     @Autowired
     AdminRepository adminRepository;
 
-    // @Value("${ADMIN_EMAILS:}")
-    // private String adminEmailsRaw;
-
-    // private List<String> adminEmails;
-
-    // @PostConstruct
-    // public void init() {
-
-    //     log.info("Loaded ADMIN_EMAILS: '{}'", adminEmailsRaw);
-
-    //     if (adminEmailsRaw != null && !adminEmailsRaw.isBlank()) {
-    //         adminEmails = List.of(adminEmailsRaw.split("\\s*,\\s*"));
-    //     } else {
-    //         adminEmails = List.of(); // default to empty list
-    //     }
-
-    //     log.info("Parsed adminEmails list: {}", adminEmails);
-
-
-    // }
-    @Value("#{'${app.admin-emails}'.split(',')}")
-    private List<String> adminEmails;
+    @Value("${app.admin.emails}")
+    private String[] protectedAdminEmails;
 
     @Operation(summary= "List all Admins")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -84,11 +62,11 @@ public class AdminController extends ApiController{
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
     public Object deleteAdmin(@Parameter(name="email") @RequestParam String email) {
-        
-        if (adminEmails.contains(email)) {
-            throw new UnsupportedOperationException("Cannot delete admin email: " + email);
-        }
 
+        if (Arrays.asList(protectedAdminEmails).contains(email)) {
+            throw new UnsupportedOperationException("Cannot delete protected admin: " + email);
+        }
+        
         Admin  admin = adminRepository.findById(email)
                 .orElseThrow(() -> new EntityNotFoundException(Admin.class, email));
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -67,4 +67,10 @@ public abstract class ApiController {
             "message", e.getMessage()
     );
   }
+
+  @ExceptionHandler(UnsupportedOperationException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public Map<String, String> handleUnsupportedOperation(UnsupportedOperationException ex) {
+        return Map.of("message", ex.getMessage());
+    }
 }

--- a/src/main/resources/db/migration/changes/007-create-Admins.json
+++ b/src/main/resources/db/migration/changes/007-create-Admins.json
@@ -2,8 +2,8 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "Admins-1",
-        "author": "JasonZ",
+        "id": "007-create-Admins",
+        "author": "jasozh5",
         "preConditions": [
           {
             "onFail": "MARK_RAN"

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/AdminControllerTests.java
@@ -1,0 +1,201 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import edu.ucsb.cs156.frontiers.controllers.AdminController;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import org.springframework.test.context.TestPropertySource;
+
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@TestPropertySource(properties = {
+    "app.admin.emails=testadmin@ucsb.edu"
+})
+@WebMvcTest(controllers = AdminController.class)
+@Import(TestConfig.class)
+public class AdminControllerTests extends ControllerTestCase{
+    @MockBean
+    AdminRepository adminRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    private AdminController adminController;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/admin/admins/all"))
+                            .andExpect(status().is(403)); 
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_canot_get_all() throws Exception {
+            mockMvc.perform(get("/api/admin/admins/all"))
+                            .andExpect(status().is(403)); 
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/admin/admins/all"))
+                            .andExpect(status().is(200)); 
+    }
+
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/admin/admins/post"))
+                                .andExpect(status().is(403));
+        }
+
+    
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/admin/admins/post"))
+                                .andExpect(status().is(403));
+        }
+
+
+
+     @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_user_can_get_all() throws Exception {
+
+                Admin admin = Admin.builder()
+                    .email("jasonz2005@gmail.com")
+                    .build();
+
+
+                ArrayList<Admin> expectedAdmin = new ArrayList<>();
+                expectedAdmin.addAll(Arrays.asList(admin));
+
+                when(adminRepository.findAll()).thenReturn(expectedAdmin);
+
+                MvcResult response = mockMvc.perform(get("/api/admin/admins/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+
+                verify(adminRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedAdmin);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void an_admin_user_can_post_a_new_admin() throws Exception {
+            
+              Admin admin = Admin.builder()
+                    .email("jasonz2005@gmail.com")
+                    .build();
+
+                when(adminRepository.save(eq(admin))).thenReturn(admin);
+
+                MvcResult response = mockMvc.perform(
+                                post("/api/admin/admins/post?email=jasonz2005@gmail.com")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                verify(adminRepository, times(1)).save(admin);
+                String expectedJson = mapper.writeValueAsString(admin);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+     
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_delete_a_admin() throws Exception {
+
+                Admin admin = Admin.builder()
+                    .email("jasonz2005@gmail.com")
+                    .build();
+
+                when(adminRepository.findById(eq("jasonz2005@gmail.com"))).thenReturn(Optional.of(admin));
+
+
+                MvcResult response = mockMvc.perform(
+                                delete("/api/admin/admins?email=jasonz2005@gmail.com")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                verify(adminRepository, times(1)).findById("jasonz2005@gmail.com");
+                verify(adminRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Admin with email is deleted", json.get("message"));
+        }
+        
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_tries_to_delete_non_existant_admin_and_gets_right_error_message() throws Exception {
+
+                when(adminRepository.findById(eq("jasonz2005@gmail.com"))).thenReturn(Optional.empty());
+
+                MvcResult response = mockMvc.perform(
+                                delete("/api/admin/admins?email=jasonz2005@gmail.com")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                verify(adminRepository, times(1)).findById("jasonz2005@gmail.com");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Admin with id jasonz2005@gmail.com not found", json.get("message"));
+        }
+
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_cannot_delete_protected_admin_email() throws Exception {
+            String protectedEmail = "protected@ucsb.edu";
+    
+            ReflectionTestUtils.setField(adminController, "protectedAdminEmails", new String[]{ protectedEmail });
+
+            MvcResult response = mockMvc.perform(
+                    delete("/api/admin/admins?email=protected@ucsb.edu")
+                            .with(csrf()))
+                    .andExpect(status().isForbidden()) 
+                    .andReturn();
+
+            verify(adminRepository, times(0)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertTrue(((String) json.get("message")).contains("Cannot delete protected admin: " + protectedEmail));
+        }
+
+        
+
+}


### PR DESCRIPTION
Closes #11 

Merge #38 before this PR

In this PR, I added a AdminController.java file with backend CRUD operations. This includes a POST, GET, and DELETE, but no GET by id or PUT as per the instructions. The DELETE will return an error 403 if attempting to delete an email in the ADMIN_EMAILS on dokku variable or in the .env file. All crud operations are only accessible to someone with the Admin Role. 

Also added a AdminControllerTests.java file which contains tests which all pass and satisfy line coverage and mutation testing. This also tests the DELETE returning a 403 error. 

Note: the endpoints are /admin/admins/... to match frontend which was created by Ruben

Dokku: https://proj-dev-jasozh5.dokku-09.cs.ucsb.edu/ 

# To test:
1.) Go to the dokku listed above and log in with google and github.
2.) Click swagger in the top left
3.) find the Admins section 
4.) Click through each of the endpoints and test the functionality of them. 
5.) Make sure to create an entry with an email in ADMIN_EMAILS and then attempt to delete it

# Screenshots:
![image](https://github.com/user-attachments/assets/302d8691-c5b3-476d-bc2d-593d58bb9e88)
![image](https://github.com/user-attachments/assets/de776615-3f43-45a4-991b-ae4f86ce2ad4)
![image](https://github.com/user-attachments/assets/7b1f0b3c-1f16-4c73-8999-979107556f8c)
![image](https://github.com/user-attachments/assets/1ea65d59-a6cc-4600-9227-f7fec9ecee59)

