### PR TITLE
AK - Instructors Table(Entity, Repository, db-Migration) 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.frontiers.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * JPA entity representing an instructor.
+ * Uses email as the primary key.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class Instructor {
+    @Id
+    private String email;
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.frontiers.repositories;
 
 import edu.ucsb.cs156.frontiers.entities.Instructor;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -9,6 +9,4 @@ import org.springframework.stereotype.Repository;
  * Provides CRUD operations for the Instructor entity using email as the primary key.
  */
 @Repository
-public interface InstructorRepository extends CrudRepository<Instructor, String> {
-
-}
+public interface InstructorRepository extends JpaRepository<Instructor, String> {}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.frontiers.repositories;
+
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for Instructor entities.
+ * Provides CRUD operations for the Instructor entity using email as the primary key.
+ */
+@Repository
+public interface InstructorRepository extends CrudRepository<Instructor, String> {
+
+}

--- a/src/main/resources/db/migration/changes/009-Instructors-create.json
+++ b/src/main/resources/db/migration/changes/009-Instructors-create.json
@@ -2,8 +2,8 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "Instructors-create",
-        "author": "Andrew Kim",
+        "id": "009-Instructors-create",
+        "author": "andrewkim102",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/migration/changes/009-Instructors-create.json
+++ b/src/main/resources/db/migration/changes/009-Instructors-create.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "Instructors-create",
-        "author": "your-name",
+        "author": "Andrew Kim",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/migration/changes/nnn-Instructors-create.json
+++ b/src/main/resources/db/migration/changes/nnn-Instructors-create.json
@@ -1,0 +1,29 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Instructors-create",
+        "author": "your-name",
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "instructor",
+              "columns": [
+                {
+                  "column": {
+                    "name": "email",
+                    "type": "VARCHAR(255)",
+                    "constraints": {
+                      "primaryKey": true,
+                      "nullable": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #7 

In this PR, we're just adding the necessary files mentioned above for the Instructors repository with only one id field. Nothing else needs to be set up- just only the visibility of the H2 console/postgres.

![image](https://github.com/user-attachments/assets/8fcb352c-f2ba-41e9-b521-3e912c409a5e)
