### PR TITLE
MB- add roster student table, stories, and tests

### DIFF
--- a/frontend/src/fixtures/rosterStudentFixtures.js
+++ b/frontend/src/fixtures/rosterStudentFixtures.js
@@ -1,0 +1,40 @@
+const rosterStudentFixtures = {
+  oneRosterStudent: [
+    {
+      id: 1,
+      enrollmentCode: "12345",
+      studentId: "123456789",
+      firstName: "John",
+      lastName: "Doe",
+      email: "johndoe@example.com",
+    },
+  ],
+  threeRosterStudents: [
+    {
+      id: 1,
+      enrollmentCode: "12345",
+      studentId: "123456789",
+      firstName: "John",
+      lastName: "Doe",
+      email: "johndoe@example.com",
+    },
+    {
+      id: 2,
+      enrollmentCode: "23456",
+      studentId: "234567890",
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "janedoe@example.com",
+    },
+    {
+      id: 3,
+      enrollmentCode: "34567",
+      studentId: "345678901",
+      firstName: "Alex",
+      lastName: "Smith",
+      email: "alexsmith@example.com",
+    },
+  ],
+};
+
+export { rosterStudentFixtures };

--- a/frontend/src/fixtures/rosterStudentFixtures.js
+++ b/frontend/src/fixtures/rosterStudentFixtures.js
@@ -2,7 +2,6 @@ const rosterStudentFixtures = {
   oneRosterStudent: [
     {
       id: 1,
-      enrollmentCode: "12345",
       studentId: "123456789",
       firstName: "John",
       lastName: "Doe",
@@ -12,7 +11,6 @@ const rosterStudentFixtures = {
   threeRosterStudents: [
     {
       id: 1,
-      enrollmentCode: "12345",
       studentId: "123456789",
       firstName: "John",
       lastName: "Doe",
@@ -20,7 +18,6 @@ const rosterStudentFixtures = {
     },
     {
       id: 2,
-      enrollmentCode: "23456",
       studentId: "234567890",
       firstName: "Jane",
       lastName: "Doe",
@@ -28,7 +25,6 @@ const rosterStudentFixtures = {
     },
     {
       id: 3,
-      enrollmentCode: "34567",
       studentId: "345678901",
       firstName: "Alex",
       lastName: "Smith",

--- a/frontend/src/main/components/RosterStudent/RosterStudentTable.js
+++ b/frontend/src/main/components/RosterStudent/RosterStudentTable.js
@@ -1,0 +1,92 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+// Helper for DELETE request
+// Stryker disable StringLiteral : hard to test for string literals
+export const cellToAxiosParamsDelete = (cell) => {
+  return {
+    url: "/api/rosterstudents",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+};
+// Stryker restore StringLiteral
+
+// Stryker disable all : hard to test for console logs
+export const onDeleteSuccess = (message) => {
+  console.log("Delete successful:", message);
+};
+// Stryker restore all
+
+export default function RosterStudentTable({ rosterStudents, currentUser }) {
+  const navigate = useNavigate();
+
+  // Stryker disable next-line StringLiteral : hard to test for string literals
+  const editCallback = (cell) => {
+    navigate(`/rosterstudent/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/rosterstudents/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  // Stryker disable next-line ArrayDeclaration : hard to test for array literals
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+    {
+      Header: "Enrollment Code",
+      accessor: "enrollmentCode",
+    },
+    {
+      Header: "Student ID",
+      accessor: "studentId",
+    },
+    {
+      Header: "First Name",
+      accessor: "firstName",
+    },
+    {
+      Header: "Last Name",
+      accessor: "lastName",
+    },
+    {
+      Header: "Email",
+      accessor: "email",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    // Stryker disable next-line BlockStatement : hard to test for block statements
+    columns.push(
+      ButtonColumn("Edit", "primary", editCallback, "RosterStudentTable"),
+    );
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, "RosterStudentTable"),
+    );
+  }
+
+  return (
+    <OurTable
+      data={rosterStudents}
+      columns={columns}
+      testid={"RosterStudentTable"}
+    />
+  );
+}

--- a/frontend/src/main/components/RosterStudent/RosterStudentTable.js
+++ b/frontend/src/main/components/RosterStudent/RosterStudentTable.js
@@ -1,41 +1,31 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+
 import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/RosterStudentUtils";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-// Helper for DELETE request
-// Stryker disable StringLiteral : hard to test for string literals
-export const cellToAxiosParamsDelete = (cell) => {
-  return {
-    url: "/api/rosterstudents",
-    method: "DELETE",
-    params: {
-      id: cell.row.values.id,
-    },
-  };
-};
-// Stryker restore StringLiteral
-
-// Stryker disable all : hard to test for console logs
-export const onDeleteSuccess = (message) => {
-  console.log("Delete successful:", message);
-};
-// Stryker restore all
-
-export default function RosterStudentTable({ rosterStudents, currentUser }) {
+export default function RosterStudentTable({
+  items,
+  currentUser,
+  testIdPrefix = "RosterStudentTable",
+}) {
   const navigate = useNavigate();
 
-  // Stryker disable next-line StringLiteral : hard to test for string literals
   const editCallback = (cell) => {
     navigate(`/rosterstudent/edit/${cell.row.values.id}`);
   };
 
   // Stryker disable all : hard to test for query caching
+
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/rosterstudents/all"],
+    ["/api/rosterstudent/all"],
   );
   // Stryker restore all
 
@@ -44,16 +34,12 @@ export default function RosterStudentTable({ rosterStudents, currentUser }) {
     deleteMutation.mutate(cell);
   };
 
-  // Stryker disable next-line ArrayDeclaration : hard to test for array literals
   const columns = [
     {
       Header: "id",
       accessor: "id", // accessor is the "key" in the data
     },
-    {
-      Header: "Enrollment Code",
-      accessor: "enrollmentCode",
-    },
+
     {
       Header: "Student ID",
       accessor: "studentId",
@@ -73,20 +59,11 @@ export default function RosterStudentTable({ rosterStudents, currentUser }) {
   ];
 
   if (hasRole(currentUser, "ROLE_ADMIN")) {
-    // Stryker disable next-line BlockStatement : hard to test for block statements
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
     columns.push(
-      ButtonColumn("Edit", "primary", editCallback, "RosterStudentTable"),
-    );
-    columns.push(
-      ButtonColumn("Delete", "danger", deleteCallback, "RosterStudentTable"),
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
     );
   }
 
-  return (
-    <OurTable
-      data={rosterStudents}
-      columns={columns}
-      testid={"RosterStudentTable"}
-    />
-  );
+  return <OurTable data={items} columns={columns} testid={testIdPrefix} />;
 }

--- a/frontend/src/main/utils/RosterStudentUtils.js
+++ b/frontend/src/main/utils/RosterStudentUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/rosterstudent",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/RosterStudent/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudent/RosterStudentTable.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
 import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-// Remove the 'rest' import since it's not being used
+import { http, HttpResponse } from "msw";
 
 export default {
   title: "components/RosterStudent/RosterStudentTable",
@@ -16,25 +16,23 @@ const Template = (args) => {
 export const Empty = Template.bind({});
 
 Empty.args = {
-  rosterStudents: [],
+  items: [],
+  currentUser: currentUserFixtures.userOnly,
 };
 
-export const ThreeRosterStudents = Template.bind({});
-
-ThreeRosterStudents.args = {
-  rosterStudents: rosterStudentFixtures.threeRosterStudents,
-};
-
-export const ThreeRosterStudentsAsAdmin = Template.bind({});
-
-ThreeRosterStudentsAsAdmin.args = {
-  rosterStudents: rosterStudentFixtures.threeRosterStudents,
+export const ThreeStudentsAdminUser = Template.bind({});
+ThreeStudentsAdminUser.args = {
+  items: rosterStudentFixtures.threeRosterStudents,
   currentUser: currentUserFixtures.adminUser,
 };
 
-export const ThreeRosterStudentsAsUser = Template.bind({});
-
-ThreeRosterStudentsAsUser.args = {
-  rosterStudents: rosterStudentFixtures.threeRosterStudents,
-  currentUser: currentUserFixtures.userOnly,
+ThreeStudentsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/rosterstudent", () => {
+      return HttpResponse.json(
+        { message: "Student deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
 };

--- a/frontend/src/stories/components/RosterStudent/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudent/RosterStudentTable.stories.js
@@ -1,0 +1,40 @@
+import React from "react";
+import RosterStudentTable from "main/components/RosterStudent/RosterStudentTable";
+import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+// Remove the 'rest' import since it's not being used
+
+export default {
+  title: "components/RosterStudent/RosterStudentTable",
+  component: RosterStudentTable,
+};
+
+const Template = (args) => {
+  return <RosterStudentTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  rosterStudents: [],
+};
+
+export const ThreeRosterStudents = Template.bind({});
+
+ThreeRosterStudents.args = {
+  rosterStudents: rosterStudentFixtures.threeRosterStudents,
+};
+
+export const ThreeRosterStudentsAsAdmin = Template.bind({});
+
+ThreeRosterStudentsAsAdmin.args = {
+  rosterStudents: rosterStudentFixtures.threeRosterStudents,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+export const ThreeRosterStudentsAsUser = Template.bind({});
+
+ThreeRosterStudentsAsUser.args = {
+  rosterStudents: rosterStudentFixtures.threeRosterStudents,
+  currentUser: currentUserFixtures.userOnly,
+};

--- a/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
+++ b/frontend/src/tests/components/RosterStudent/RosterStudentTable.test.js
@@ -1,0 +1,209 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { rosterStudentFixtures } from "fixtures/rosterStudentFixtures";
+import RosterStudentTable, {
+  cellToAxiosParamsDelete,
+} from "main/components/RosterStudent/RosterStudentTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+const mockedNavigate = jest.fn();
+const mockedMutate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+jest.mock("main/utils/useBackend", () => ({
+  ...jest.requireActual("main/utils/useBackend"),
+  useBackendMutation: () => ({
+    mutate: mockedMutate,
+  }),
+}));
+
+describe("RosterStudentTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable rosterStudents={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  test("renders without crashing for three roster students", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable
+            rosterStudents={rosterStudentFixtures.threeRosterStudents}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  test("Has the expected column headers and content", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable
+            rosterStudents={rosterStudentFixtures.threeRosterStudents}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Enrollment Code",
+      "Student ID",
+      "First Name",
+      "Last Name",
+      "Email",
+    ];
+    const expectedFields = [
+      "id",
+      "enrollmentCode",
+      "studentId",
+      "firstName",
+      "lastName",
+      "email",
+    ];
+    const testId = "RosterStudentTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-enrollmentCode`),
+    ).toHaveTextContent("12345");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-enrollmentCode`),
+    ).toHaveTextContent("23456");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable
+            rosterStudents={rosterStudentFixtures.threeRosterStudents}
+            currentUser={currentUserFixtures.adminUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("RosterStudentTable-cell-row-0-col-id"),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      "RosterStudentTable-cell-row-0-col-Edit-button",
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // Test the Edit button has the primary style
+    expect(editButton).toHaveClass("btn-primary");
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/rosterstudent/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback for admin user", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable
+            rosterStudents={rosterStudentFixtures.threeRosterStudents}
+            currentUser={currentUserFixtures.adminUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("RosterStudentTable-cell-row-0-col-id"),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      "RosterStudentTable-cell-row-0-col-Delete-button",
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // Test the Delete button has the danger style
+    expect(deleteButton).toHaveClass("btn-danger");
+
+    fireEvent.click(deleteButton);
+
+    // Check that the mutate function was called
+    await waitFor(() => expect(mockedMutate).toHaveBeenCalled());
+  });
+
+  test("Edit and Delete buttons are not rendered for non-admin user", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RosterStudentTable
+            rosterStudents={rosterStudentFixtures.threeRosterStudents}
+            currentUser={currentUserFixtures.userOnly}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("RosterStudentTable-cell-row-0-col-id"),
+    ).toHaveTextContent("1");
+
+    expect(
+      screen.queryByTestId("RosterStudentTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("RosterStudentTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  // Test the cellToAxiosParamsDelete function directly
+  test("cellToAxiosParamsDelete returns the correct parameters", () => {
+    // Create a mock cell object that matches the structure expected by the function
+    const cell = {
+      row: {
+        values: {
+          id: 5,
+        },
+      },
+    };
+
+    // Call the function and check its output
+    const result = cellToAxiosParamsDelete(cell);
+    expect(result).toEqual({
+      url: "/api/rosterstudents",
+      method: "DELETE",
+      params: {
+        id: 5,
+      },
+    });
+  });
+});

--- a/frontend/src/tests/utils/rosterStudent.test.js
+++ b/frontend/src/tests/utils/rosterStudent.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/RosterStudentUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("RosterStudentUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/rosterstudent",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #24   

In this PR, we add the StudentRosterTable, that shows the fields studentId, the first and last name of the student, as well as their email. NOTE: Will only be accessible to admin.

View the storybook here: https://6823eb897f17ca4b3da8b15d-kablajaxiz.chromatic.com/?path=/story/components-rosterstudent-rosterstudenttable--empty

# Screenshots
![image](https://github.com/user-attachments/assets/63ebd60c-5e26-417c-8868-4993776fa73c)

![image](https://github.com/user-attachments/assets/b87996ee-c5b9-47a4-98ee-107bc0e42f76)
