### PR TITLE
MB-issue01-v2small, Fixed 403 Issue for Google Github Login for Null

### DIFF
--- a/frontend/src/main/components/Nav/GithubLogin.js
+++ b/frontend/src/main/components/Nav/GithubLogin.js
@@ -7,6 +7,12 @@ export default function GithubLogin({ currentUser, systemInfo }) {
   if (!currentUser || !currentUser.loggedIn) {
     return <span data-testid="GithubLogin-logged-out" />;
   }
+
+  // Add this null check for currentUser.root.user
+  if (!currentUser.root?.user) {
+    return <span data-testid="GithubLogin-loading" />;
+  }
+
   if (currentUser.root.user.githubLogin) {
     return (
       <>

--- a/frontend/src/main/components/Nav/GoogleLogin.js
+++ b/frontend/src/main/components/Nav/GoogleLogin.js
@@ -5,7 +5,7 @@ export default function GoogleLogin({ currentUser, systemInfo, doLogout }) {
   var oauthLogin = systemInfo?.oauthLogin || "/oauth2/authorization/google";
   return (
     <>
-      {currentUser && currentUser.loggedIn ? (
+      {currentUser && currentUser.loggedIn && currentUser.root?.user ? (
         <>
           <Navbar.Text className="me-3" as={Link} to="/profile">
             Welcome, {currentUser.root.user.email}

--- a/frontend/src/tests/components/Nav/GithubLogin.test.js
+++ b/frontend/src/tests/components/Nav/GithubLogin.test.js
@@ -35,6 +35,77 @@ describe("GithubLogin tests", () => {
     expect(loginButton).toBeInTheDocument();
   });
 
+  test("renders loading when currentUser is null", async () => {
+    const currentUser = null;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the logged-out span
+    const loggedOutElement = screen.getByTestId("GithubLogin-logged-out");
+    expect(loggedOutElement).toBeInTheDocument();
+  });
+
+  test("renders loading when currentUser.root is null", async () => {
+    const currentUser = {
+      loggedIn: true,
+      root: null,
+    };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the loading span
+    const loadingElement = screen.getByTestId("GithubLogin-loading");
+    expect(loadingElement).toBeInTheDocument();
+  });
+
+  test("renders loading when currentUser.root.user is null", async () => {
+    const currentUser = {
+      loggedIn: true,
+      root: {
+        user: null,
+      },
+    };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GithubLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the loading span
+    const loadingElement = screen.getByTestId("GithubLogin-loading");
+    expect(loadingElement).toBeInTheDocument();
+  });
+
   test("default link is the correct value", async () => {
     const currentUser = currentUserFixtures.userOnly;
 

--- a/frontend/src/tests/components/Nav/GoogleLogin.test.js
+++ b/frontend/src/tests/components/Nav/GoogleLogin.test.js
@@ -71,4 +71,139 @@ describe("GoogleLogin tests", () => {
     expect(loginButton).toBeInTheDocument();
     expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
   });
+
+  test("renders login button when currentUser is null", async () => {
+    const currentUser = null;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+
+  test("renders login button when currentUser.loggedIn is false", async () => {
+    const currentUser = {
+      loggedIn: false,
+      root: { user: { email: "test@test.com" } },
+    };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+
+  test("renders login button when currentUser.root is null", async () => {
+    const currentUser = { loggedIn: true, root: null };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+
+  test("renders login button when currentUser.root.user is null", async () => {
+    const currentUser = { loggedIn: true, root: { user: null } };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+
+  test("renders login button when currentUser.root.user is undefined", async () => {
+    const currentUser = { loggedIn: true, root: { user: undefined } };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
+
+  test("renders login button when currentUser.root.user is false", async () => {
+    const currentUser = { loggedIn: true, root: { user: false } };
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GoogleLogin
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Check for the login button
+    const loginButton = screen.getByText("Log In");
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toHaveAttribute("href", "/oauth2/authorization/google");
+  });
 });


### PR DESCRIPTION
## Solving Google, Github Login Issue



Solves part of #1, offshoot of #27, should be merged prior to #27

DOKKU LINK:   https://proj-frontiers-s25-09.dokku-09.cs.ucsb.edu
### Problem
The original code in `GoogleLogin.js`, 'GithubLogin.js' used this conditional:

### Test Plan
If on main this error should appear as evident and described below, on my current branch this error will not be prompted. 


```javascript
{currentUser && currentUser.loggedIn ? (

```
This caused a 403 Forbidden error when currentUser.root.user was null, undefined, or otherwise falsy. Although currentUser.loggedIn was true, the nested user object was sometimes missing due to async loading or malformed state. As a result, the application attempted to render components that assumed user data existed, triggering errors or protected route failures.


### Solution
```javascript
{currentUser && currentUser.loggedIn && currentUser.root?.user ? (
```

This adds a third safety check to confirm that currentUser.root and currentUser.root.user both exist before proceeding. It uses optional chaining to avoid runtime crashes or broken rendering logic when user data is still loading. It ensures the app doesn't assume user identity is ready until all required fields are populated., this logic also expanded to GithubLogin.js extending to a null check added



### Tests Added

#### 📁 GithubLogin.test.js

- **Renders logged-out state** when `currentUser = null`  
  → Expects element with `data-testid="GithubLogin-logged-out"`

- **Renders loading state** when:
  - `currentUser.root = null`
  - `currentUser.root.user = null`  
  → Expects element with `data-testid="GithubLogin-loading"`

#### 📁 GoogleLogin.test.js

- **Renders "Log In" button** when:
  - `currentUser = null`
  - `currentUser.loggedIn = false`
  - `currentUser.root = null`
  - `currentUser.root.user = null`
  - `currentUser.root.user = undefined`
  - `currentUser.root.user = false`  
  → Expects "Log In" button with `href="/oauth2/authorization/google"`



