### PR TITLE
AK - application-development.properties Adjustment #1

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,6 +1,6 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.url=jdbc:h2:file:./target/db-development;AUTO_SERVER=TRUE
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true


### PR DESCRIPTION
By setting the `AUTO_SERVER=TRUE` parameter added into the `spring.datasource.url`, it enables for H2's ability to allow for multiple connections to the same database file simultaneously. This then allows for us to both run our Spring Boot app to run and also the H2 console.

I accidentally happened to discover this when working with the .env files, and although it didn't influence anything, it allowed for the ability to work with both applications for an ease of inspection.

https://github.com/ucsb-cs156-s25/proj-frontiers-s25-09/pull/46#discussion_r2103602348
^ Comment