### PR TITLE
AK - application-development.properties Adjustment #2

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,4 +9,4 @@ app.showSwaggerUILink=true
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
-spring.config.import=optional:file:./secrets.yaml
+spring.config.import=optional:file:./secrets.yaml,optional:file:.env[.properties]

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -10,3 +10,4 @@ app.showSwaggerUILink=true
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
 spring.config.import=optional:file:./secrets.yaml,optional:file:.env[.properties]
+app.admin.emails=${ADMIN_EMAILS:admin1@example.com,admin2@example.com,admin3@example.com}


### PR DESCRIPTION
The addition of `,optional:file:.env[.properties]` allows Spring Boto to load the configuration from the `.env` files or any `.env.properties` files if they exist, allowing for us(admins) to quickly add the emails necessary for users managing and controlling the databases. 

Furthermore, in future additions to this project, future developers can just `.env` files to add and override any defaults without having to manually add to the `application-development.propertes`. 

Finally, it'll still operate as a fallback in the `.env` file doesn't exist/is missing. 



https://github.com/ucsb-cs156-s25/proj-frontiers-s25-09/pull/46#discussion_r2103602487